### PR TITLE
Removed Quantopian link from Data APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,6 @@ There are two general approaches to investing: active and passive. Active invest
 	- [Polygon - APIs for Stocks, Forex and Crypto](https://www.polygon.io/)
 	- [SEC-API.io](https://www.sec-api.io/)
 	- [Alpha Vantage](https://www.alphavantage.co/)
-	- [Quantopian](https://www.quantopian.com/)
 	- [Norgate Data - Financial Market Data for Stocks, Futures and Forex](https://norgatedata.com/)
 	###### [TOC](#toc)
 


### PR DESCRIPTION
Quantopian has shut down, so the link to the site should be removed.